### PR TITLE
Add Analytics tab with SwiftUI charts

### DIFF
--- a/contributions/ContentView.swift
+++ b/contributions/ContentView.swift
@@ -68,11 +68,16 @@ struct ContentView: View {
           Label("Contributions", systemImage: "chart.dots.scatter")
         }
         .tag(0)
+      AnalyticsView()
+        .tabItem {
+          Label("Analytics", systemImage: "chart.bar.doc.horizontal")
+        }
+        .tag(1)
       SettingsView(userStore: userStore)
         .tabItem {
           Label("Settings", systemImage: "gearshape")
         }
-        .tag(1)
+        .tag(2)
     }
   }
 
@@ -156,7 +161,7 @@ struct ContentView: View {
       }
 
       Button {
-        selectedTab = 1
+        selectedTab = 2
       } label: {
         Label("Go to Settings", systemImage: "gearshape")
           .font(.headline)

--- a/contributions/views/analytics/AnalyticsView.swift
+++ b/contributions/views/analytics/AnalyticsView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import Charts
+
+struct AnalyticsView: View {
+    @EnvironmentObject var userStore: UserStore
+    @State private var contributions: [String: [ContributionDay]] = [:]
+    @State private var isLoading = true
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if userStore.users.isEmpty {
+                    Text("Add users to view analytics")
+                        .foregroundColor(.secondary)
+                        .padding()
+                } else if isLoading {
+                    ProgressView()
+                        .padding()
+                } else {
+                    VStack(spacing: 24) {
+                        StreakChart(users: userStore.users, data: contributions)
+                        SevenDayContributionsBarChart(users: userStore.users, data: contributions)
+                        MonthlyTotalsPieChart(users: userStore.users, data: contributions)
+                        DailyAverageLineChart(users: userStore.users, data: contributions)
+                    }
+                    .padding()
+                }
+            }
+            .navigationTitle("Analytics")
+            .task {
+                await loadData()
+            }
+        }
+    }
+
+    private func loadData() async {
+        var temp: [String: [ContributionDay]] = [:]
+        for user in userStore.users {
+            do {
+                let data = try await GitHubService.shared.fetchContributions(username: user.username)
+                temp[user.username] = data
+            } catch {
+                print("AnalyticsView: failed to fetch contributions for \(user.username) -> \(error)")
+            }
+        }
+        await MainActor.run {
+            self.contributions = temp
+            self.isLoading = false
+        }
+    }
+}
+
+#Preview {
+    AnalyticsView()
+        .environmentObject(UserStore())
+}

--- a/contributions/views/analytics/charts/DailyAverageLineChart.swift
+++ b/contributions/views/analytics/charts/DailyAverageLineChart.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import Charts
+
+struct DailyAverageLineChart: View {
+    let users: [UserSettings]
+    let data: [String: [ContributionDay]]
+
+    private var last30Dates: [String] {
+        if let first = data.values.first, let lastDateStr = first.last?.date {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            guard let lastDate = formatter.date(from: lastDateStr) else { return [] }
+            return (0..<30).reversed().compactMap { offset in
+                let date = Calendar.current.date(byAdding: .day, value: -offset, to: lastDate)
+                return date.map { formatter.string(from: $0) }
+            }
+        }
+        return []
+    }
+
+    private func count(for user: UserSettings, date: String) -> Int {
+        data[user.username]?.first(where: { $0.date == date })?.contributionCount ?? 0
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Daily Averages")
+                .font(.headline)
+            Chart {
+                ForEach(users, id: \..username) { user in
+                    ForEach(last30Dates, id: \..self) { day in
+                        LineMark(
+                            x: .value("Day", day),
+                            y: .value("Contributions", count(for: user, date: day))
+                        )
+                        .foregroundStyle(by: .value("User", user.username))
+                    }
+                }
+            }
+            .chartForegroundStyleScale(
+                domain: users.map { $0.username },
+                range: users.map { $0.colorTheme.color(for: 4) }
+            )
+            .frame(height: 200)
+        }
+    }
+}

--- a/contributions/views/analytics/charts/MonthlyTotalsPieChart.swift
+++ b/contributions/views/analytics/charts/MonthlyTotalsPieChart.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import Charts
+
+struct MonthlyTotalsPieChart: View {
+    let users: [UserSettings]
+    let data: [String: [ContributionDay]]
+
+    private func total(for user: UserSettings) -> Int {
+        guard let contribs = data[user.username] else { return 0 }
+        let recent = contribs.suffix(30)
+        return recent.reduce(0) { $0 + $1.contributionCount }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Monthly Totals")
+                .font(.headline)
+            Chart {
+                ForEach(users, id: \..username) { user in
+                    SectorMark(
+                        angle: .value("Total", total(for: user))
+                    )
+                    .foregroundStyle(by: .value("User", user.username))
+                }
+            }
+            .chartForegroundStyleScale(
+                domain: users.map { $0.username },
+                range: users.map { $0.colorTheme.color(for: 4) }
+            )
+            .frame(height: 200)
+        }
+    }
+}

--- a/contributions/views/analytics/charts/SevenDayContributionsBarChart.swift
+++ b/contributions/views/analytics/charts/SevenDayContributionsBarChart.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import Charts
+
+struct SevenDayContributionsBarChart: View {
+    let users: [UserSettings]
+    let data: [String: [ContributionDay]]
+
+    private var last7Dates: [String] {
+        if let first = data.values.first, let lastDateStr = first.last?.date {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            guard let lastDate = formatter.date(from: lastDateStr) else { return [] }
+            return (0..<7).reversed().compactMap { offset in
+                let date = Calendar.current.date(byAdding: .day, value: -offset, to: lastDate)
+                return date.map { formatter.string(from: $0) }
+            }
+        }
+        return []
+    }
+
+    private func count(for user: UserSettings, date: String) -> Int {
+        data[user.username]?.first(where: { $0.date == date })?.contributionCount ?? 0
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Last 7 Days")
+                .font(.headline)
+            Chart {
+                ForEach(last7Dates, id: \..self) { day in
+                    ForEach(users, id: \..username) { user in
+                        BarMark(
+                            x: .value("Day", day),
+                            y: .value("Contributions", count(for: user, date: day))
+                        )
+                        .foregroundStyle(by: .value("User", user.username))
+                    }
+                }
+            }
+            .chartForegroundStyleScale(
+                domain: users.map { $0.username },
+                range: users.map { $0.colorTheme.color(for: 4) }
+            )
+            .frame(height: 200)
+        }
+    }
+}

--- a/contributions/views/analytics/charts/StreakChart.swift
+++ b/contributions/views/analytics/charts/StreakChart.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import Charts
+
+struct StreakChart: View {
+    enum TimeFrame: String, CaseIterable, Identifiable {
+        case week = "Week"
+        case month = "Month"
+        var id: String { rawValue }
+        var days: Int { self == .week ? 7 : 30 }
+    }
+
+    let users: [UserSettings]
+    let data: [String: [ContributionDay]]
+    @State private var frame: TimeFrame = .week
+
+    private func streak(for user: UserSettings) -> Int {
+        guard let contributions = data[user.username] else { return 0 }
+        let recent = contributions.suffix(frame.days)
+        var count = 0
+        for day in recent.reversed() {
+            if day.contributionCount > 0 { count += 1 } else { break }
+        }
+        return count
+    }
+
+    private var sortedUsers: [UserSettings] {
+        users.sorted { streak(for: $0) > streak(for: $1) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("On Fire 🔥")
+                .font(.headline)
+
+            Picker("", selection: $frame) {
+                ForEach(TimeFrame.allCases) { tf in
+                    Text(tf.rawValue).tag(tf)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.vertical, 4)
+
+            Chart {
+                ForEach(sortedUsers.prefix(5), id: \..username) { user in
+                    BarMark(
+                        x: .value("User", user.username),
+                        y: .value("Streak", streak(for: user))
+                    )
+                    .foregroundStyle(user.colorTheme.color(for: 4))
+                }
+            }
+            .frame(height: 200)
+        }
+    }
+}

--- a/contributions/views/analytics/charts/StreakChart.swift
+++ b/contributions/views/analytics/charts/StreakChart.swift
@@ -1,55 +1,83 @@
-import SwiftUI
 import Charts
+import SwiftUI
 
 struct StreakChart: View {
-    enum TimeFrame: String, CaseIterable, Identifiable {
-        case week = "Week"
-        case month = "Month"
-        var id: String { rawValue }
-        var days: Int { self == .week ? 7 : 30 }
+  enum TimeFrame: String, CaseIterable, Identifiable {
+    case week = "Week"
+    case month = "Month"
+    var id: String { rawValue }
+    var days: Int { self == .week ? 7 : 30 }
+  }
+
+  let users: [UserSettings]
+  let data: [String: [ContributionDay]]
+  @State private var frame: TimeFrame = .week
+
+  private func streak(for user: UserSettings) -> Int {
+    guard let contributions = data[user.username] else { return 0 }
+    let recent = contributions.suffix(frame.days)
+    var count = 0
+    for day in recent.reversed() {
+      if day.contributionCount > 0 { count += 1 } else { break }
     }
+    return count
+  }
 
-    let users: [UserSettings]
-    let data: [String: [ContributionDay]]
-    @State private var frame: TimeFrame = .week
+  private var sortedUsers: [UserSettings] {
+    users.sorted { streak(for: $0) > streak(for: $1) }
+  }
 
-    private func streak(for user: UserSettings) -> Int {
-        guard let contributions = data[user.username] else { return 0 }
-        let recent = contributions.suffix(frame.days)
-        var count = 0
-        for day in recent.reversed() {
-            if day.contributionCount > 0 { count += 1 } else { break }
+  var body: some View {
+    VStack(alignment: .leading) {
+      Text("On Fire 🔥")
+        .font(.headline)
+
+      Picker("", selection: $frame) {
+        ForEach(TimeFrame.allCases) { tf in
+          Text(tf.rawValue).tag(tf)
         }
-        return count
-    }
+      }
+      .pickerStyle(.segmented)
+      .padding(.vertical, 4)
 
-    private var sortedUsers: [UserSettings] {
-        users.sorted { streak(for: $0) > streak(for: $1) }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading) {
-            Text("On Fire 🔥")
-                .font(.headline)
-
-            Picker("", selection: $frame) {
-                ForEach(TimeFrame.allCases) { tf in
-                    Text(tf.rawValue).tag(tf)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.vertical, 4)
-
-            Chart {
-                ForEach(sortedUsers.prefix(5), id: \..username) { user in
-                    BarMark(
-                        x: .value("User", user.username),
-                        y: .value("Streak", streak(for: user))
-                    )
-                    .foregroundStyle(user.colorTheme.color(for: 4))
-                }
-            }
-            .frame(height: 200)
+      Chart {
+        ForEach(sortedUsers.prefix(5), id: \.username) { user in
+          BarMark(
+            x: .value("User", user.username),
+            y: .value("Streak", streak(for: user))
+          )
+          .foregroundStyle(user.colorTheme.color(for: 4))
         }
+      }
+      .frame(height: 200)
+
+      // Horizontal scrollable cards for top users
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 16) {
+          ForEach(sortedUsers.prefix(5), id: \.username) { user in
+            VStack(spacing: 8) {
+              CachedAvatarView(username: user.username, size: 44)
+              Text(user.username)
+                .font(.subheadline)
+                .fontWeight(.medium)
+              Text("\(weeklyContributions(for: user)) this week")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+            .padding(12)
+            .background(Color(.systemBackground).opacity(0.9))
+            .cornerRadius(12)
+            .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 1)
+          }
+        }
+        .padding(.horizontal, 4)
+      }
     }
+  }
+
+  // Helper to sum last 7 days' contributions
+  private func weeklyContributions(for user: UserSettings) -> Int {
+    guard let contributions = data[user.username] else { return 0 }
+    return contributions.suffix(TimeFrame.week.days).reduce(0) { $0 + $1.contributionCount }
+  }
 }


### PR DESCRIPTION
## Summary
- add new `AnalyticsView` with multiple charts
- implement `StreakChart`, `SevenDayContributionsBarChart`, `MonthlyTotalsPieChart`, and `DailyAverageLineChart`
- integrate Analytics tab in the main `TabView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68646254f8b08320a702d50144c945e1